### PR TITLE
Add indexed keyword to Source class

### DIFF
--- a/src/poetry/config/source.py
+++ b/src/poetry/config/source.py
@@ -9,6 +9,7 @@ class Source:
     url: str
     default: bool = dataclasses.field(default=False)
     secondary: bool = dataclasses.field(default=False)
+    indexed: bool = dataclasses.field(default=False)
 
     def to_dict(self) -> dict[str, str | bool]:
         return dataclasses.asdict(self)


### PR DESCRIPTION
I just tried out your branch and it is working great. I can finally install PyTorch using poetry. Thank you for the work.

I do however get an error when I try to add a repository to pyproject.toml using `poetry source add` if the pyproject.toml contains the indexed keyword.

I fixed this by making the Source class aware of the new keyword.

## Error
```
TypeError

  Source.__init__() got an unexpected keyword argument 'indexed'

  at src/poetry/poetry.py:78 in <listcomp>
       74│         return self
       75│
       76│     def get_sources(self) -> list[Source]:
       77│         return [
    →  78│             Source(**source)
       79│             for source in self.pyproject.poetry_config.get("source", [])
       80│         ]
       81│
```

## pyproject.toml
```toml
[tool.poetry]
name = "test"
version = "0.1.0"
description = ""
authors = ["test@test.test"]
readme = "README.md"

[tool.poetry.dependencies]
python = "~3.8"
numpy = "^1.22"

[build-system]
requires = ["poetry-core"]
build-backend = "poetry.core.masonry.api"

[[tool.poetry.source]]
name = "pytorch"
url = "https://download.pytorch.org/whl/cu115/"
default = false
secondary = true
indexed = true
```


